### PR TITLE
Minor fix for pi.excerpt.php

### DIFF
--- a/third_party/excerpt/pi.excerpt.php
+++ b/third_party/excerpt/pi.excerpt.php
@@ -120,7 +120,7 @@ Class Excerpt {
 	 * @access	public
 	 * @return	string
 	 */
-	function usage()
+	public static function usage()
 	{
 		ob_start(); 
 		?>


### PR DESCRIPTION
Fixed: "Message: Non-static method Excerpt::usage() should not be called statically, assuming $this from incompatible context"
